### PR TITLE
🗄 Factor the opinionated validation out of BaseController

### DIFF
--- a/server/src/modules/users/application/use-cases/create-user/create-user-controller.ts
+++ b/server/src/modules/users/application/use-cases/create-user/create-user-controller.ts
@@ -1,13 +1,25 @@
 import express from 'express'
-import { BaseController } from '../../../../../shared/app/base-controller'
+import { UseCaseController } from '../../../../../shared/app/use-case-controller'
 import { CreateUserUseCase } from './create-user-use-case'
 import { CreateUserDTO, createUserDTOSchema } from './create-user-dto'
 import { CreateUserErrors } from './create-user-errors'
 import { UserValueObjectErrors } from '../../../domain/value-objects/errors'
+import { Result } from '../../../../../shared/core/result'
+import { ValidationError } from 'joi'
 
-export class CreateUserController extends BaseController<CreateUserUseCase> {
-  constructor(useCase: CreateUserUseCase) {
-    super(useCase, createUserDTOSchema)
+export class CreateUserController extends UseCaseController<CreateUserUseCase> {
+  constructor(useCase: CreateUserUseCase) { super(useCase) }
+
+  buildDTO(req: express.Request): Result<CreateUserDTO, Array<ValidationError>> {
+    const errs: Array<ValidationError> = []
+    const bodyResult = this.validate(req.body, createUserDTOSchema)
+    if (bodyResult.isOk()) {
+      const body = bodyResult.value
+      return Result.ok(body)
+    } else {
+      errs.push(bodyResult.error)
+      return Result.err(errs)
+    }
   }
 
   async executeImpl(dto: CreateUserDTO, res: express.Response): Promise<express.Response> {

--- a/server/src/modules/users/application/use-cases/create-user/create-user-use-case.ts
+++ b/server/src/modules/users/application/use-cases/create-user/create-user-use-case.ts
@@ -34,7 +34,7 @@ export class CreateUserUseCase
 
     const results = [emailResult, passwordResult] as const
     if (!Result.resultsAllOk(results)) {
-      return Result.err(Result.getFirstError([emailResult, passwordResult]).error)
+      return Result.err(Result.getFirstError(results).error)
     }
 
     const email = results[0].value

--- a/server/src/shared/app/typed-controller.ts
+++ b/server/src/shared/app/typed-controller.ts
@@ -1,0 +1,31 @@
+import * as express from 'express'
+import Joi, { ValidationError } from 'joi'
+import { Result } from '../core/result'
+import { BaseController } from './base-controller'
+
+export abstract class TypedController<DTO> extends BaseController {
+  protected abstract buildDTO(req: express.Request): Result<DTO, Array<ValidationError>>
+
+  protected validate<T>(obj: unknown, schema: Joi.ObjectSchema<T>): Result<T, ValidationError> {
+    const { error } = schema.validate(obj)
+    return (error === undefined) ? Result.ok(obj as T) : Result.err(error)
+  }
+
+  public async execute(req: express.Request, res: express.Response): Promise<express.Response> {
+    try {
+      const dtoResult = this.buildDTO(req)
+      if (dtoResult.isOk()) {
+        return await this.executeImpl(dtoResult.value, res)
+      } else {
+        const message = dtoResult.error.map(err => err.message).join('\n\n')
+        return this.clientError(res, message)
+      }
+    } catch (err) {
+      console.log(`[BaseController]: Uncaught controller error`)
+      console.log(err)
+      return this.fail(res, 'An unexpected error occurred')
+    }
+  }
+
+  protected abstract executeImpl(dto: DTO, res: express.Response): Promise<express.Response | void | any>
+}

--- a/server/src/shared/app/use-case-controller.ts
+++ b/server/src/shared/app/use-case-controller.ts
@@ -1,0 +1,10 @@
+import { TypedController } from './typed-controller'
+import { BaseUseCase } from './base-use-case'
+
+type extractDTO<UseCase> = UseCase extends BaseUseCase<infer T, any> ? T : never
+
+export abstract class UseCaseController<UseCase> extends TypedController<extractDTO<UseCase>> {
+  constructor(protected readonly useCase: UseCase) {
+    super()
+  }
+}

--- a/server/src/shared/core/result.ts
+++ b/server/src/shared/core/result.ts
@@ -28,26 +28,22 @@ export namespace Result {
   export const ok = <T, E>(value: T): Result<T, E> => new Ok(value)
   export const err = <T, E>(error: E): Result<T, E> => new Err(error)
   export function resultsAllOk<T1, T2, E1, E2>(
-    results: readonly [Result<T1, E2>, Result<T2, E2>]
-  ): results is [Ok<T1, E2>, Ok<T2, E2>]
-
-  export function resultsAllOk(results: any): any {
+    results: readonly [Result<T1, E1>, Result<T2, E2>]
+  ): results is [Ok<T1, E1>, Ok<T2, E2>] {
     for (const result of results) {
       if (result.isErr()) return false
     }
-
     return true
   }
 
   export function getFirstError<T1, T2, E1, E2>(
-    results: [Result<T1, E1>, Result<T2, E2>]
+    results: readonly [Result<T1, E1>, Result<T2, E2>]
   ): Err<T1, E1> | Err<T2, E2> {
     let err: Err<T1, E1> | Err<T2, E2> | null = null
 
     for (const result of results) {
       if (result.isErr()) {
         return (err = result)
-        break
       }
     }
 


### PR DESCRIPTION
## Purpose
`BaseController` validation was being too opinionated about things:
* assuming that you have a DTO at all
* assuming that the DTO is part of the request body

This change fixes both of the above problems, as well as an outstanding bug in the `Result` implementation.

## Approach
`BaseController` is now splattered into a chain of 3 abstract classes:
* `BaseController` now makes no assumptions and its only purpose is to support HTTP requests. Endpoints that don't care about the request contents at all can extend this class.
* `TypedController<DTO> extends BaseController` specifies a DTO type; an object of that type must be built (and validated) within the abstract `buildDTO` method.
* `UseCaseController<UseCase> extends TypedController<extractDTO<UseCase>>` captures the DTO type of its corresponding `UseCase`. Most controllers will probably extend this class.

## Testing
Passed all unit tests 🧪 

#### Open Questions and Pre-Merge TODOs
- [ ] Where would user authentication would go in this chain of classes? Would it be a class in itself?
- [ ] See the Appendix for a bothersome architecture problem.

## Learning
Figuring out this structure was less about learning new techniques and more about understanding our own design.

## Appendix

`buildDTO` is meant to be implemented by calling `this.validate(...)` on things we want to type-check and then using the result. An example with a single call to `this.validate(...)` can be seen in this PR.

The intent of the `Array<ValidationError>` error type is so that we return every validation error encountered when building the DTO; this is so that we communicate requirements clearly to API users. However, this implementation requirement means we cannot short-circuit. Instead, we have to gather all the `Result`s before checking if all of them are OK. If they are, then we carry on with constructing the DTO object. If they are not, then we have to gather all of the errors.

It's not possible (at least not in a type-safe way) for us to check whether every result in an arbitrarily-sized collection is OK and subsequently use the result. Instead, we will have to write functions like `Result.resultsAllOk` to do it for arrays of fixed size. Maybe this is a reason for us to just be lazy and use short-circuiting, or maybe we should infiltrate the Typescript team and introduce smarter type-guards.

Co-authored-by: jeffzh4ng zhang.jeffreyd.@gmail.com
Co-authored-by: KTong821 <email>
Co-authored-by: ShreyasPrasad <email>