### PR TITLE
🗄 delete is_deleted column

### DIFF
--- a/server/src/migrations/Migration20210123215506.ts
+++ b/server/src/migrations/Migration20210123215506.ts
@@ -5,4 +5,5 @@ export class Migration20210123215506 extends Migration {
     this.addSql('create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null);');
     this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");');
   }
+
 }

--- a/server/src/migrations/Migration20210123215506.ts
+++ b/server/src/migrations/Migration20210123215506.ts
@@ -3,6 +3,6 @@ import { Migration } from '@mikro-orm/migrations';
 export class Migration20210123215506 extends Migration {
   async up(): Promise<void> {
     this.addSql('create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null);');
-    this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");')
+    this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");');
   }
 }

--- a/server/src/migrations/Migration20210123215506.ts
+++ b/server/src/migrations/Migration20210123215506.ts
@@ -1,4 +1,4 @@
-import { Migration } from '@mikro-orm/migrations'
+import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20210123215506 extends Migration {
   async up(): Promise<void> {

--- a/server/src/migrations/Migration20210123215506.ts
+++ b/server/src/migrations/Migration20210123215506.ts
@@ -1,6 +1,7 @@
 import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20210123215506 extends Migration {
+
   async up(): Promise<void> {
     this.addSql('create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null);');
     this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");');

--- a/server/src/migrations/Migration20210123215506.ts
+++ b/server/src/migrations/Migration20210123215506.ts
@@ -1,10 +1,10 @@
-import { Migration } from '@mikro-orm/migrations';
+import { Migration } from '@mikro-orm/migrations'
 
 export class Migration20210123215506 extends Migration {
-
   async up(): Promise<void> {
-    this.addSql('create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null, "is_deleted" bool not null default false);');
-    this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");');
+    this.addSql(
+      'create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null);'
+    )
+    this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");')
   }
-
 }

--- a/server/src/migrations/Migration20210123215506.ts
+++ b/server/src/migrations/Migration20210123215506.ts
@@ -2,9 +2,7 @@ import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20210123215506 extends Migration {
   async up(): Promise<void> {
-    this.addSql(
-      'create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null);'
-    )
+    this.addSql('create table "club" ("id" varchar(255) not null, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "description" varchar(255) not null);');
     this.addSql('alter table "club" add constraint "club_pkey" primary key ("id");')
   }
 }


### PR DESCRIPTION
## Purpose
Tiny fix to clean up migrations files. Extra "is_deleted" column was added to get-all-clubs PR https://github.com/loolabs/waterpark/pull/33 which should have been deleted. This PR basically cleans up the migrations for the get-all-events PR https://github.com/loolabs/waterpark/pull/50.

## Approach
Deleting one line in the clubs migration.

## Testing
Passes all tests, runs on Docker.
