### PR TITLE
💻 Fixing mobile logo showing on initial load

### DIFF
--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -56,7 +56,7 @@ export const NavBar = () => {
   return (
     <NavBarContainer>
       <Link href="/">
-        {width > 450 ? (
+        {width > 425 ? (
           <Logo src="/Waterpark.svg" alt="Waterpark logo" />
         ) : (
           <Logo src="/W.svg" alt="Waterpark logo" />

--- a/client/components/hooks/UseViewport.tsx
+++ b/client/components/hooks/UseViewport.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
 export const useViewport = () => {
-    const [width, setWidth] = useState(0);
+  const [width, setWidth] = useState(window.innerWidth)
 
-    useEffect(() => {
-        const handleWindowResize = () => setWidth(window.innerWidth);
-        window.addEventListener("resize", handleWindowResize);
-        return () => window.removeEventListener("resize", handleWindowResize);
-    }, []);
+  useEffect(() => {
+    const handleWindowResize = () => setWidth(window.innerWidth)
+    window.addEventListener('resize', handleWindowResize)
+    return () => window.removeEventListener('resize', handleWindowResize)
+  }, [])
 
-    return { width };
+  return { width }
 }

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
-import { AppProvider } from "../context"
-import { NavBar } from "../components/NavBar"
+import { AppProvider } from '../context'
+import dynamic from 'next/dynamic'
+
+const DynamicNavBar = dynamic(() => import('../components/NavBar').then((mod) => mod.NavBar), {
+  ssr: false,
+})
 
 function App({ Component, pageProps }: AppProps) {
   return (
     <AppProvider>
-      <NavBar/>
+      <DynamicNavBar />
       <Component {...pageProps} />
     </AppProvider>
   )

--- a/client/styles/typography.ts
+++ b/client/styles/typography.ts
@@ -51,7 +51,7 @@ export const fontWeight = Object.freeze({
   regular: weight400,
 })
 
-export const PageTitle = styled.span`
+export const PageTitle = styled.h1`
   font-style: normal;
   font-weight: ${fontWeight.semiBold};
   font-size: ${desktopFontSize.h1};


### PR DESCRIPTION
## Screenshots
![image](https://user-images.githubusercontent.com/18248358/111885414-02381500-899e-11eb-8ef0-202177ccc588.png)

## Purpose
Initially was loading the mobile logo. https://recordit.co/oVL7wKg5nY.

## Approach
Dynamically importing the navbar is the only way to ensure the correct logo is displayed on the initial load.
https://nextjs.org/docs/advanced-features/dynamic-import#with-no-ssr
