### PR TITLE
💻 Add header to events page

### DIFF
--- a/client/components/SearchInput.tsx
+++ b/client/components/SearchInput.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { colours, fontWeight, fontInter } from '../../styles'
+import { colours, fontWeight, fontInter } from '../styles'
 
 const mobile = `425px`
 const tablet = `768px`

--- a/client/components/clubs/ClubList.tsx
+++ b/client/components/clubs/ClubList.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 import styled from 'styled-components'
 import { ClubCard } from './ClubCard'
 import { PageTitle } from '../../styles'
-import { SearchInput } from './SearchInput'
+import { SearchInput } from '../SearchInput'
 
 const mobile = `425px`
 const tablet = `768px`

--- a/client/components/events/EventViewToggle.tsx
+++ b/client/components/events/EventViewToggle.tsx
@@ -31,8 +31,9 @@ const EventViewToggleContainer = styled.div<any>`
 const EventViewToggleButtons = styled.div<any>`
   display: flex;
   margin-bottom: 60px;
-  cursor: pointer;
   margin-left: 200px;
+  margin-top: 40px;
+  cursor: pointer;
   @media ${device.tablet} {
     margin-left: 0px;
   }

--- a/client/components/events/EventViewToggle.tsx
+++ b/client/components/events/EventViewToggle.tsx
@@ -2,10 +2,11 @@ import React, { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { EventCalendarView } from './EventCalendarView'
 import { EventListView } from './EventListView/EventListView'
+import { EventsHeader } from './EventsHeader'
 import { Event } from '../../utils'
-import { colours, device, fontWeight, desktopFontSize, mobileFontSize } from '../../styles'
+import { device } from '../../styles'
 import styled from 'styled-components'
-import { FilteredEvents } from '../../pages/events'
+import { useSearch } from '../hooks'
 
 enum View {
   list = 'list',
@@ -13,6 +14,7 @@ enum View {
 }
 
 interface EventViewProps {
+  onSearch: (search: string) => any
   events: Map<string, Array<Event>>
 }
 
@@ -45,7 +47,7 @@ const ToggleText = styled.div<any>`
   margin-right: 24px;
 `
 
-export const EventViewToggle = ({ events }: EventViewProps) => {
+export const EventViewToggle = ({ events, onSearch }: EventViewProps) => {
   const router = useRouter()
 
   const { view } = router.query
@@ -69,6 +71,7 @@ export const EventViewToggle = ({ events }: EventViewProps) => {
 
   return (
     <EventViewToggleContainer>
+      <EventsHeader onSearch={onSearch} />
       <EventViewToggleButtons>
         <EventViewToggleButton
           activeView={formattedView}

--- a/client/components/events/EventsHeader.tsx
+++ b/client/components/events/EventsHeader.tsx
@@ -1,0 +1,82 @@
+import { TAGS, Tag, TagGroup, TagRow, TagBubble } from '../clubs/Tag' // TODO: rearrange our dependencies to avoid this
+import styled from 'styled-components'
+import { PageTitle } from '../../styles'
+import { SearchInput } from '../SearchInput'
+
+const mobile = `425px`
+const tablet = `768px`
+const laptop = `1024px`
+
+const smallerThan = (size: string): string => `(max-width: ${size})`
+const largerThan = (size: string): string => `(min-width: ${size})`
+
+const EventListHeaderContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+  width: 100%;
+
+  // Shrink the page's "forehead" on mobile
+  gap: 8px;
+  margin-top: max(48px, 5vh);
+  @media ${largerThan(tablet)} {
+    gap: 16px;
+    margin-top: 10vh;
+  }
+`
+
+const EventListTitleRow = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  height: 64px;
+`
+
+const EventListTitle = styled(PageTitle)`
+  margin: 0;
+  white-space: nowrap;
+`
+
+const RightSpaceWrapper = styled.div`
+  padding-right: 16px;
+  margin-right: auto;
+`
+
+interface EventListHeaderProps {
+  onSearch: (search: string) => any
+}
+
+interface EventListTagsProps {
+  tags: Array<Tag>
+}
+
+const ClubListTags = ({ tags }: EventListTagsProps) => {
+  return (
+    <TagRow>
+      <TagGroup>
+        {tags.map(({ text, colour }) => (
+          <RightSpaceWrapper key={text}>
+            <TagBubble colour={colour} highlightOnHover>
+              {text}
+            </TagBubble>
+          </RightSpaceWrapper>
+        ))}
+      </TagGroup>
+      <TagBubble borderStyle="dashed" borderWidth="2px">
+        + More
+      </TagBubble>
+    </TagRow>
+  )
+}
+
+export const EventsHeader = ({ onSearch }: EventListHeaderProps) => {
+  return (
+    <EventListHeaderContainer>
+      <EventListTitleRow>
+        <EventListTitle>Explore Events</EventListTitle>
+        <SearchInput onChange={(e) => onSearch(e.target.value)} placeholder="Search" />
+      </EventListTitleRow>
+      <ClubListTags tags={Array.from(TAGS.values())}></ClubListTags>
+    </EventListHeaderContainer>
+  )
+}

--- a/client/pages/events/index.tsx
+++ b/client/pages/events/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { EventViewToggle } from '../../components/events'
+import { useSearch } from '../../components/hooks'
 import { useAppContext } from '../../context'
 import { Event } from '../../utils'
 
@@ -12,7 +13,7 @@ export interface FilteredEvents {
 
 export default function Events() {
   const { events } = useAppContext()
-  const filteredEventsArray = Array.from(events.values())
+  const [filteredEventsArray, setSearchValue] = useSearch(Array.from(events.values()), ['name'])
 
   //this requires that filteredEventsArray is in sorted order (with respect to event startDate)
   const filteredEventsDateMap: Map<string, Array<Event>> = new Map()
@@ -28,5 +29,5 @@ export default function Events() {
 
   const filteredEvents: Map<string, Array<Event>> = filteredEventsDateMap
 
-  return <EventViewToggle events={filteredEvents} />
+  return <EventViewToggle events={filteredEvents} onSearch={setSearchValue} />
 }


### PR DESCRIPTION
## Screenshots

https://youtu.be/NKigUdlXkpg

## Purpose

Closes #121 

Also hook up event search to the events page. At the moment this performs filtering before everything else (including the creation of the map from days to events). This may or may not be ideal, pending future discussion.

## Approach

Reuses the same header components from the clubs page, but duplicates the code. If we were to properly turn the header into a common component, the refactor could break a bunch of changes in the pipeline. Some future refactor is needed.

## Testing

Visually verified in screencap