### PR TITLE
💻 Make navbar responsive on mobile

### DIFF
--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -90,25 +90,6 @@ LogoWaterpark.defaultProps = {
   alt: 'Waterpark logo',
 }
 
-const NavbarItemsStyling = styled.div`
-  display: flex;
-  justify-content: space-between;
-
-  @media ${smallerThan(width.mobile)} {
-    flex-direction: column;
-    align-items: flex-end;
-  }
-`
-
-const NavBarContainer = styled.div`
-  position: fixed;
-  top: 0;
-  z-index: 8;
-  width: 100%;
-  box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
-  background-color: white;
-`
-
 const HideOnMobile = styled.div`
   @media ${smallerThan(width.mobile)} {
     display: none;
@@ -121,10 +102,10 @@ const ShowOnMobile = styled.div`
   }
 `
 
-const NavbarItems = () => {
+const NavbarItems = styled(({ className }: { className?: string }) => {
   const router = useRouter()
   return (
-    <NavbarItemsStyling>
+    <div className={className}>
       <Link href="/housing">
         <NavBarOption isActive={router.pathname == '/housing' || router.pathname == '/'}>
           Housing
@@ -136,9 +117,17 @@ const NavbarItems = () => {
       <Link href="/washrooms">
         <NavBarOption isActive={router.pathname == '/washrooms'}>Washrooms</NavBarOption>
       </Link>
-    </NavbarItemsStyling>
+    </div>
   )
-}
+})`
+  display: flex;
+  justify-content: space-between;
+
+  @media ${smallerThan(width.mobile)} {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+`
 
 const HamburgerMenu = styled.img<{ active: boolean }>`
   padding: 5px;
@@ -163,11 +152,11 @@ const NavBarDropdown = styled.div`
   }
 `
 
-export const NavBar = () => {
+export const NavBar = styled(({ className }: { className?: string }) => {
   let [openDrawer, setOpenDrawer] = useState(false)
 
   return (
-    <NavBarContainer>
+    <div className={className}>
       <NavBarRow>
         <Link href="/">
           <LogoContainer>
@@ -196,6 +185,13 @@ export const NavBar = () => {
           <NavbarItems />
         </NavBarDropdown>
       </ShowOnMobile>
-    </NavBarContainer>
+    </div>
   )
-}
+})`
+  position: fixed;
+  top: 0;
+  z-index: 8;
+  width: 100%;
+  box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
+  background-color: white;
+`

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -19,7 +19,6 @@ const NavBarRow = styled.div`
   justify-content: space-between;
   align-items: center;
   background: ${colours.white};
-  padding: 14px 24px;
 `
 
 const NavBarOption = styled.a<any>`
@@ -63,6 +62,7 @@ const LogoW = styled.img`
   @media ${smallerThan(width.tablet)} {
     display: block;
   }
+  padding: 14px 24px;
 `
 LogoW.defaultProps = {
   src: '/W.svg',
@@ -74,6 +74,7 @@ const LogoWaterpark = styled.img`
   @media ${smallerThan(width.tablet)} {
     display: none;
   }
+  padding: 14px 24px;
 `
 LogoWaterpark.defaultProps = {
   src: '/Waterpark.svg',
@@ -102,6 +103,7 @@ const NavBarContainer = styled.div`
 // There is a hardcoded drop-down max-height value. It is equal to 46 * (number of navigation elements, currently 3).
 // 46 = Height of nav text + height of top and bottom margins.
 // Why hardcoded: CSS transitions cannot accept auto values. So, we need to calculate the height before animating.
+// TODO: fix hardcode animation
 const NavBarDropdown = styled.div`
   overflow: hidden;
   transition-property: max-height;
@@ -145,6 +147,7 @@ const NavbarItems = () => {
 
 const HamburgerMenu = styled.img<{ active: boolean }>`
   padding: 5px;
+  margin-right: 14px;
   border-style: solid;
   border-width: 1px;
   border-radius: 5px;
@@ -170,8 +173,8 @@ export const NavBar = () => {
           <HamburgerMenu
             src={window.location.origin + '/hamburger-menu.svg'}
             alt="dropdown"
-            height="27"
-            width="27"
+            height="35"
+            width="35"
             onClick={() => {
               setOpenDrawer(!openDrawer)
             }}

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -21,11 +21,18 @@ const NavBarRow = styled.div`
   background: ${colours.white};
 `
 
+// Constants declared for animation purposes
+const NavBarHeightSpacing = 4
+const NavBarMobileFontSize = 18
+const NavBarMobileVertMargin = 12
+const NavBarOptionHeight = 2 * NavBarMobileVertMargin + NavBarMobileFontSize + NavBarHeightSpacing
+const NumberOfNavbarItems = 3
+
 const NavBarOption = styled.a<any>`
   font-style: normal;
   font-weight: ${fontWeight.bold};
   font-size: ${desktopFontSize.subtitle1};
-  line-height: 120%;
+  line-height: ${NavBarHeightSpacing + NavBarMobileFontSize}px;
   text-transform: uppercase;
   color: ${colours.neutralDark1};
   ${(props: any) =>
@@ -41,8 +48,8 @@ const NavBarOption = styled.a<any>`
   }
 
   @media ${smallerThan(width.mobileL)} {
-    font-size: ${mobileFontSize.subtitle1};
-    margin: 12px 12px;
+    font-size: ${NavBarMobileFontSize}px;
+    margin: ${NavBarMobileVertMargin}px 12px;
   }
 
   &:hover {
@@ -64,6 +71,7 @@ const LogoW = styled.img`
   }
   padding: 14px 24px;
 `
+
 LogoW.defaultProps = {
   src: '/W.svg',
   alt: 'Waterpark logo',
@@ -76,6 +84,7 @@ const LogoWaterpark = styled.img`
   }
   padding: 14px 24px;
 `
+
 LogoWaterpark.defaultProps = {
   src: '/Waterpark.svg',
   alt: 'Waterpark logo',
@@ -98,20 +107,6 @@ const NavBarContainer = styled.div`
   width: 100%;
   box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
   background-color: white;
-`
-
-// There is a hardcoded drop-down max-height value. It is equal to 46 * (number of navigation elements, currently 3).
-// 46 = Height of nav text + height of top and bottom margins.
-// Why hardcoded: CSS transitions cannot accept auto values. So, we need to calculate the height before animating.
-// TODO: fix hardcode animation
-const NavBarDropdown = styled.div`
-  overflow: hidden;
-  transition-property: max-height;
-  transition: 0.2s ease-in-out;
-  max-height: 0px;
-  &.dropped-down {
-    max-height: 138px;
-  }
 `
 
 const HideOnMobile = styled.div`
@@ -152,6 +147,20 @@ const HamburgerMenu = styled.img<{ active: boolean }>`
   border-width: 1px;
   border-radius: 5px;
   background-color: ${(props) => (props.active ? colours.neutralLight1 : colours.white)};
+`
+
+// There is a hardcoded drop-down max-height value. It is equal to 46 * (number of navigation elements, currently 3).
+// 46 = Height of nav text + height of top and bottom margins.
+// Why hardcoded: CSS transitions cannot accept auto values. So, we need to calculate the height before animating.
+// TODO: fix hardcode animation
+const NavBarDropdown = styled.div`
+  overflow: hidden;
+  transition-property: max-height;
+  transition: 0.2s ease-in-out;
+  max-height: 0px;
+  &.dropped-down {
+    max-height: ${NumberOfNavbarItems * NavBarOptionHeight}px;
+  }
 `
 
 export const NavBar = () => {

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -60,7 +60,7 @@ const LogoContainer = styled.div`
 
 const LogoW = styled.img`
   display: none;
-  @media (max-width: 768px) {
+  @media ${device.tablet} {
     display: block;
   }
 `
@@ -71,7 +71,7 @@ LogoW.defaultProps = {
 
 const LogoWaterpark = styled.img`
   display: block;
-  @media (max-width: 768px) {
+  @media ${device.tablet} {
     display: none;
   }
 `

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -1,6 +1,14 @@
 import React, { useState } from 'react'
 import styled, { css } from 'styled-components'
-import { colours, fontWeight, desktopFontSize, mobileFontSize, width, smallerThan, largerThan } from '../styles'
+import {
+  colours,
+  fontWeight,
+  desktopFontSize,
+  mobileFontSize,
+  width,
+  smallerThan,
+  largerThan,
+} from '../styles'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
@@ -92,9 +100,9 @@ const NavBarContainer = styled.div`
 `
 
 // There is a hardcoded drop-down max-height value. It is equal to 46 * (number of navigation elements, currently 3).
-// "Why 46?" Height of nav text + height of top and bottom margins.
-// "Why is it hardcoded?" CSS transitions cannot accept auto values. So, we need to calculate the height before animating.
-const NavBarDropdown = styled.div<{ openDrawer: boolean }>`
+// 46 = Height of nav text + height of top and bottom margins.
+// Why hardcoded: CSS transitions cannot accept auto values. So, we need to calculate the height before animating.
+const NavBarDropdown = styled.div`
   overflow: hidden;
   transition-property: max-height;
   transition: 0.2s ease-in-out;
@@ -159,7 +167,7 @@ export const NavBar = () => {
         </HideOnMobile>
         <ShowOnMobile>
           <HamburgerMenu
-            src={window.location.origin + "/hamburger-menu.svg"}
+            src={window.location.origin + '/hamburger-menu.svg'}
             alt="dropdown"
             height="27"
             width="27"
@@ -170,7 +178,7 @@ export const NavBar = () => {
         </ShowOnMobile>
       </NavBarRow>
       <ShowOnMobile>
-        <NavBarDropdown openDrawer={openDrawer} className={openDrawer ? 'dropped-down' : ''}>
+        <NavBarDropdown className={openDrawer ? 'dropped-down' : ''}>
           <NavbarItems />
         </NavBarDropdown>
       </ShowOnMobile>

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -43,7 +43,7 @@ const NavBarOption = styled.a<any>`
 
   @media ${device.mobileL} {
     font-size: ${mobileFontSize.subtitle1};
-    margin: 8px 12px;
+    margin: 12px 12px;
   }
 
   &:hover {
@@ -86,6 +86,7 @@ const NavbarItemsStyling = styled.div`
 
   @media ${device.mobileL} {
     flex-direction: column;
+    align-items: flex-end;
   }
 `
 
@@ -105,7 +106,7 @@ const NavBarDropdown = styled.div<{ openDrawer: boolean }>`
   transition: 0.2s ease-in-out;
   max-height: 0px;
   &.dropped-down {
-    max-height: 114px;
+    max-height: 138px;
   }
 `
 

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -32,8 +32,8 @@ const NavBarOption = styled.a<any>`
     `};
   margin: 0px 32px;
 
-  @media ${device.mobileL} {
-    font-size: ${mobileFontSize.subtitle1};
+  @media ${device.tablet} {
+    font-size: ${mobileFontSize.subtitle2};
     margin: 0px 13px;
   }
 
@@ -51,7 +51,7 @@ const LogoContainer = styled.div`
 
 const LogoW = styled.img`
   display: none;
-  @media (max-width: 425px) {
+  @media (max-width: 768px) {
     display: block;
   }
 `
@@ -62,7 +62,7 @@ LogoW.defaultProps = {
 
 const LogoWaterpark = styled.img`
   display: block;
-  @media (max-width: 425px) {
+  @media (max-width: 768px) {
     display: none;
   }
 `
@@ -70,6 +70,12 @@ LogoWaterpark.defaultProps = {
   src: '/Waterpark.svg',
   alt: 'Waterpark logo',
 }
+
+const NavbarItems = styled.div`
+  display: flex;
+  justify-content: space-between;
+  min-width: 300px;
+`
 
 export const NavBar = () => {
   const router = useRouter()
@@ -82,7 +88,7 @@ export const NavBar = () => {
           <LogoW />
         </LogoContainer>
       </Link>
-      <div>
+      <NavbarItems>
         <Link href="/housing">
           <NavBarOption isActive={router.pathname == '/housing' || router.pathname == '/'}>
             Housing
@@ -94,7 +100,7 @@ export const NavBar = () => {
         <Link href="/washrooms">
           <NavBarOption isActive={router.pathname == '/washrooms'}>Washrooms</NavBarOption>
         </Link>
-      </div>
+      </NavbarItems>
     </NavBarContainer>
   )
 }

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -167,7 +167,7 @@ export const NavBar = () => {
         </HideOnMobile>
         <ShowOnMobile>
           <HamburgerMenu
-            src="hamburger-menu.svg"
+            src="./hamburger-menu.svg"
             alt="dropdown"
             height="27"
             width="27"

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -1,10 +1,18 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled, { css } from 'styled-components'
-import { colours, device, fontWeight, desktopFontSize, mobileFontSize } from '../styles'
+import {
+  colours,
+  device,
+  fontWeight,
+  desktopFontSize,
+  mobileFontSize,
+  largerThan,
+  mobile,
+} from '../styles'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-const NavBarContainer = styled.div`
+const NavBarRow = styled.div`
   width: 100%;
   display: flex;
   flex-direction: row;
@@ -12,10 +20,6 @@ const NavBarContainer = styled.div`
   align-items: center;
   background: ${colours.white};
   padding: 14px 24px;
-  box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
-  position: fixed;
-  top: 0;
-  z-index: 1;
 `
 
 const NavBarOption = styled.a<any>`
@@ -34,7 +38,12 @@ const NavBarOption = styled.a<any>`
 
   @media ${device.tablet} {
     font-size: ${mobileFontSize.subtitle2};
-    margin: 0px 13px;
+    margin: 0px 8px;
+  }
+
+  @media ${device.mobileL} {
+    font-size: ${mobileFontSize.subtitle1};
+    margin: 8px 12px;
   }
 
   &:hover {
@@ -71,36 +80,105 @@ LogoWaterpark.defaultProps = {
   alt: 'Waterpark logo',
 }
 
-const NavbarItems = styled.div`
+const NavbarItemsStyling = styled.div`
   display: flex;
   justify-content: space-between;
-  min-width: 300px;
+
+  @media ${device.mobileL} {
+    flex-direction: column;
+  }
+`
+
+const NavBarContainer = styled.div`
+  position: fixed;
+  top: 0;
+  z-index: 1;
+  width: 100%;
+  box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
+  background-color: white;
+`
+
+// There is a hardcoded drop-down max-height value. It is equal to 38 * (number of navigation elements).
+const NavBarDropdown = styled.div<{ openDrawer: boolean }>`
+  overflow: hidden;
+  transition-property: max-height;
+  transition: 0.2s ease-in-out;
+  max-height: 0px;
+  &.dropped-down {
+    max-height: 114px;
+  }
+`
+
+const HideOnMobile = styled.div`
+  @media ${device.mobileL} {
+    display: none;
+  }
+`
+
+const ShowOnMobile = styled.div`
+  @media ${largerThan(mobile)} {
+    display: none;
+  }
+`
+
+const NavbarItems = () => {
+  const router = useRouter()
+  return (
+    <NavbarItemsStyling>
+      <Link href="/housing">
+        <NavBarOption isActive={router.pathname == '/housing' || router.pathname == '/'}>
+          Housing
+        </NavBarOption>
+      </Link>
+      <Link href="/study-spots">
+        <NavBarOption isActive={router.pathname == '/study-spots'}>Study Spots</NavBarOption>
+      </Link>
+      <Link href="/washrooms">
+        <NavBarOption isActive={router.pathname == '/washrooms'}>Washrooms</NavBarOption>
+      </Link>
+    </NavbarItemsStyling>
+  )
+}
+
+const HamburgerMenu = styled.img`
+  padding: 5px;
+  border-style: solid;
+  border-width: 2px;
+  border-radius: 5px;
 `
 
 export const NavBar = () => {
-  const router = useRouter()
+  let [openDrawer, setOpenDrawer] = useState(false)
 
   return (
     <NavBarContainer>
-      <Link href="/">
-        <LogoContainer>
-          <LogoWaterpark />
-          <LogoW />
-        </LogoContainer>
-      </Link>
-      <NavbarItems>
-        <Link href="/housing">
-          <NavBarOption isActive={router.pathname == '/housing' || router.pathname == '/'}>
-            Housing
-          </NavBarOption>
+      <NavBarRow>
+        <Link href="/">
+          <LogoContainer>
+            <LogoWaterpark />
+            <LogoW />
+          </LogoContainer>
         </Link>
-        <Link href="/study-spots">
-          <NavBarOption isActive={router.pathname == '/study-spots'}>Study Spots</NavBarOption>
-        </Link>
-        <Link href="/washrooms">
-          <NavBarOption isActive={router.pathname == '/washrooms'}>Washrooms</NavBarOption>
-        </Link>
-      </NavbarItems>
+        <HideOnMobile>
+          <NavbarItems />
+        </HideOnMobile>
+        <ShowOnMobile>
+          <HamburgerMenu
+            src="hamburger-menu.svg"
+            alt="dropdown"
+            height="27"
+            width="27"
+            onClick={() => {
+              setOpenDrawer(!openDrawer)
+            }}
+          />
+        </ShowOnMobile>
+      </NavBarRow>
+      <ShowOnMobile>
+        <NavBarDropdown openDrawer={openDrawer} className={openDrawer ? 'dropped-down' : ''}>
+          <NavbarItems />
+        </NavBarDropdown>
+      </ShowOnMobile>
     </NavBarContainer>
   )
 }

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -103,7 +103,7 @@ const NavbarItemsStyling = styled.div`
 const NavBarContainer = styled.div`
   position: fixed;
   top: 0;
-  z-index: 1;
+  z-index: 8;
   width: 100%;
   box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
   background-color: white;

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -99,7 +99,9 @@ const NavBarContainer = styled.div`
   background-color: white;
 `
 
-// There is a hardcoded drop-down max-height value. It is equal to 38 * (number of navigation elements).
+// There is a hardcoded drop-down max-height value. It is equal to 46 * (number of navigation elements, currently 3).
+// "Why 46?" Height of nav text + height of top and bottom margins.
+// "Why is it hardcoded?" CSS transitions cannot accept auto values. So, we need to calculate the height before animating.
 const NavBarDropdown = styled.div<{ openDrawer: boolean }>`
   overflow: hidden;
   transition-property: max-height;

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -143,11 +143,12 @@ const NavbarItems = () => {
   )
 }
 
-const HamburgerMenu = styled.img`
+const HamburgerMenu = styled.img<{ active: boolean }>`
   padding: 5px;
   border-style: solid;
-  border-width: 2px;
+  border-width: 1px;
   border-radius: 5px;
+  background-color: ${(props) => (props.active ? colours.neutralLight1 : colours.white)};
 `
 
 export const NavBar = () => {
@@ -174,6 +175,7 @@ export const NavBar = () => {
             onClick={() => {
               setOpenDrawer(!openDrawer)
             }}
+            active={openDrawer}
           />
         </ShowOnMobile>
       </NavBarRow>

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -167,7 +167,7 @@ export const NavBar = () => {
         </HideOnMobile>
         <ShowOnMobile>
           <HamburgerMenu
-            src="./hamburger-menu.svg"
+            src={window.location.origin + "/hamburger-menu.svg"}
             alt="dropdown"
             height="27"
             width="27"

--- a/client/public/hamburger-menu.svg
+++ b/client/public/hamburger-menu.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink" viewBox="0 0 100 80" width="40" height="40">
-  <rect width="100" height="9"></rect>
-  <rect y="30" width="100" height="9"></rect>
-  <rect y="60" width="100" height="9"></rect>
+  <rect y="5" width="100" height="6"></rect>
+  <rect y="35" width="100" height="6"></rect>
+  <rect y="65" width="100" height="6"></rect>
 </svg>

--- a/client/public/hamburger-menu.svg
+++ b/client/public/hamburger-menu.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink" viewBox="0 0 100 80" width="40" height="40">
+  <rect width="100" height="15"></rect>
+  <rect y="30" width="100" height="15"></rect>
+  <rect y="60" width="100" height="15"></rect>
+</svg>

--- a/client/public/hamburger-menu.svg
+++ b/client/public/hamburger-menu.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink" viewBox="0 0 100 80" width="40" height="40">
-  <rect width="100" height="15"></rect>
-  <rect y="30" width="100" height="15"></rect>
-  <rect y="60" width="100" height="15"></rect>
+  <rect width="100" height="9"></rect>
+  <rect y="30" width="100" height="9"></rect>
+  <rect y="60" width="100" height="9"></rect>
 </svg>


### PR DESCRIPTION
## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/58242099/125217515-d9aa9280-e28e-11eb-9e83-a6b47d9b2fd2.png)
### After:
#### Tablet:
![image](https://user-images.githubusercontent.com/58242099/125217592-1080a880-e28f-11eb-9055-b4b0186f64a9.png)
#### Phone: (This is animated but the screenshot is still)
![image](https://user-images.githubusercontent.com/58242099/125221919-0498e480-e297-11eb-8fe9-71805212c0ed.png)

## Purpose
The navbar was not responsive on devices with smaller screen width. This closes #172.

## Approach
Media queries to reduce margin and font size were used for tablets.
I created another div for the mobile dropdown and some CSS transitions for phones.

## Testing
Via visual inspection.
