### PR TITLE
💻 Refactor media breakpoints

### DIFF
--- a/client/components/Banner.tsx
+++ b/client/components/Banner.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { largerThan, tablet } from '../styles'
+import { largerThan, width } from '../styles'
 
 interface BannerProps {
   backgroundImageUrl: string
@@ -10,7 +10,7 @@ export const Banner = styled.div<BannerProps>`
   background-position: center;
   height: 20vh;
 
-  @media ${largerThan(tablet)} {
+  @media ${largerThan(width.tablet)} {
     height: 30vh;
   }
 `

--- a/client/components/DetailContainer.tsx
+++ b/client/components/DetailContainer.tsx
@@ -1,7 +1,5 @@
 import styled from 'styled-components'
-import { largerThan } from '../styles'
-
-const mobile = `425px`
+import { largerThan, width } from '../styles'
 
 export const Container = styled.div`
   display: flex;
@@ -11,7 +9,7 @@ export const Container = styled.div`
 
   width: 85%;
 
-  @media ${largerThan(mobile)} {
+  @media ${largerThan(width.mobileL)} {
     width: 65%;
   }
 `

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
-import { colours, device, fontWeight, desktopFontSize, mobileFontSize } from '../styles'
+import { colours, fontWeight, desktopFontSize, mobileFontSize, width, smallerThan } from '../styles'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
@@ -32,7 +32,7 @@ const NavBarOption = styled.a<any>`
     `};
   margin: 0px 32px;
 
-  @media ${device.mobileL} {
+  @media ${smallerThan(width.mobileL)} {
     font-size: ${mobileFontSize.subtitle1};
     margin: 0px 13px;
   }

--- a/client/components/SearchInput.tsx
+++ b/client/components/SearchInput.tsx
@@ -1,12 +1,5 @@
 import styled from 'styled-components'
-import { colours, fontWeight, fontInter } from '../styles'
-
-const mobile = `425px`
-const tablet = `768px`
-const laptop = `1024px`
-
-const smallerThan = (size: string): string => `(max-width: ${size})`
-const largerThan = (size: string): string => `(min-width: ${size})`
+import { colours, fontWeight, fontInter, width, smallerThan, largerThan } from '../styles'
 
 export const SearchInput = styled.input`
   background-image: url(/search-24px.svg);
@@ -25,7 +18,7 @@ export const SearchInput = styled.input`
   padding-left: 32px;
   padding-right: 0;
   width: 32px;
-  @media ${largerThan(tablet)} {
+  @media ${largerThan(width.tablet)} {
     background-color: ${colours.neutralLight1};
     background-position: 12px 8px;
     background-size: 32px 32px;
@@ -40,7 +33,7 @@ export const SearchInput = styled.input`
   :not(:placeholder-shown) {
     outline: none;
 
-    @media ${smallerThan(tablet)} {
+    @media ${smallerThan(width.tablet)} {
       background-color: ${colours.neutralLight1};
       background-position: 8px 4px;
       padding-left: 36px;

--- a/client/components/resource/ResourceList.tsx
+++ b/client/components/resource/ResourceList.tsx
@@ -5,15 +5,8 @@ import { Resource, Id } from '../../utils'
 import { useMemo } from 'react'
 import styled from 'styled-components'
 import { ResourceCard } from './ResourceCard'
-import { colours, PageTitle } from '../../styles'
+import { colours, PageTitle, width, smallerThan, largerThan } from '../../styles'
 import { SearchInput } from '../SearchInput'
-
-const mobile = `425px`
-const tablet = `768px`
-const laptop = `1024px`
-
-const smallerThan = (size: string): string => `(max-width: ${size})`
-const largerThan = (size: string): string => `(min-width: ${size})`
 
 const ResourceListPage = styled.div`
   margin-top: 65px;
@@ -28,12 +21,12 @@ const ResourceListGrid = styled.div`
   grid-template-columns: repeat(1, minmax(150px, 450px));
   margin-left: 12px;
   margin-right: 12px;
-  @media ${largerThan(tablet)} and ${smallerThan(laptop)} {
+  @media ${largerThan(width.tablet)} and ${smallerThan(width.laptop)} {
     grid-template-columns: repeat(2, minmax(300px, 450px));
     margin-left: 24px;
     margin-right: 24px;
   }
-  @media ${largerThan(laptop)} {
+  @media ${largerThan(width.laptop)} {
     margin: auto;
     max-width: 80%;
     grid-template-columns: 450px repeat(auto-fit, 450px);
@@ -52,7 +45,7 @@ const ResourceListHeaderContainer = styled.div`
   // Shrink the page's "forehead" on mobile
   gap: 8px;
   margin-top: max(48px, 5vh);
-  @media ${largerThan(tablet)} {
+  @media ${largerThan(width.laptop)} {
     gap: 16px;
     margin-top: 10vh;
   }

--- a/client/styles/device.ts
+++ b/client/styles/device.ts
@@ -1,4 +1,4 @@
-const width = Object.freeze({
+export const width = Object.freeze({
   mobileS: '320px',
   mobileM: '375px',
   mobileL: '425px',
@@ -9,18 +9,5 @@ const width = Object.freeze({
   desktop: '2560px',
 })
 
-export const device = Object.freeze({
-  mobileS: `(max-width: ${width.mobileS})`,
-  mobileM: `(max-width: ${width.mobileM})`,
-  mobileL: `(max-width: ${width.mobileL})`,
-  mobile: `(max-width: ${width.mobile})`,
-  tablet: `(max-width: ${width.tablet})`,
-  laptop: `(max-width: ${width.laptop})`,
-  laptopL: `(min-width: ${width.laptopL})`,
-  desktop: `(min-width: ${width.desktop})`,
-  desktopL: `(min-width: ${width.desktop})`,
-})
-
-export const mobile = '425px'
-export const tablet = `768px`
 export const largerThan = (size: string): string => `(min-width: ${size})`
+export const smallerThan = (size: string): string => `(max-width: ${size})`

--- a/client/styles/index.ts
+++ b/client/styles/index.ts
@@ -1,3 +1,3 @@
 export { colours } from './colours'
-export { device, mobile, tablet, largerThan } from './device'
+export { width, largerThan, smallerThan } from './device'
 export { desktopFontSize, mobileFontSize, fontInter, fontWeight, PageTitle } from './typography'

--- a/client/styles/typography.ts
+++ b/client/styles/typography.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { colours } from './colours'
-import { device } from './device'
+import { width, smallerThan } from './device'
 
 // font size
 const text48 = '48px'
@@ -58,7 +58,7 @@ export const PageTitle = styled.h1`
   font-size: ${desktopFontSize.h1};
   line-height: 120%;
   color: ${colours.black};
-  @media ${device.tablet} {
+  @media ${smallerThan(width.tablet)} {
     font-size: ${mobileFontSize.h1};
   }
 `


### PR DESCRIPTION
## Purpose
Closes #171.

## Approach
Previously, many files had their own const strings for `mobile`, `tablet`, and `laptop`. They also had their own `smallerThan()` and `largerThan()` functions.

Also, the main file that was supposed to regulate breakpoints, `styles/device.ts`, was not organized well. It exported a `device` object that was supposed to give templates for different breakpoints, but did not cover all possible use cases and was extremely inconsistent. E.g. `laptop` would be `max-width` and `desktop` would be `min-width` for whatever reason. Apparently people got sick of this and just started using their own breakpoints, which is detrimental to code quality.

The solution I chose was to export the original `width` object in `styles/device.ts` that had the original const strings for all device sizes. Then, I also made `smallerThan()` and `largerThan()` functions that were exported too. This covers all possible use-cases for breakpoints (both `min-width` and `max-width` for eight different breakpoints in `width`.)

Then I refactored all references to media queries in the client to refer to this file.

## Testing
Visual inspection shows that the website functions just like before.

## Miscellaneous
You may notice that there are still some media queries (namely in `navbar`) that are not properly implemented yet. This will be handled in the navbar PR (https://github.com/loolabs/waterpark/pull/173) in the near future.