### PR TITLE
💻 Replace mobile breakpoint

### DIFF
--- a/client/components/DetailContainer.tsx
+++ b/client/components/DetailContainer.tsx
@@ -9,7 +9,7 @@ export const Container = styled.div`
 
   width: 85%;
 
-  @media ${largerThan(width.mobileL)} {
+  @media ${largerThan(width.mobile)} {
     width: 65%;
   }
 `

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -32,7 +32,7 @@ const NavBarOption = styled.a<any>`
     `};
   margin: 0px 32px;
 
-  @media ${smallerThan(width.mobileL)} {
+  @media ${smallerThan(width.mobile)} {
     font-size: ${mobileFontSize.subtitle1};
     margin: 0px 13px;
   }

--- a/client/styles/device.ts
+++ b/client/styles/device.ts
@@ -2,7 +2,7 @@ export const width = Object.freeze({
   mobileS: '320px',
   mobileM: '375px',
   mobileL: '425px',
-  mobile: '1024px',
+  mobile: '425px',
   tablet: '768px',
   laptop: '1024px',
   laptopL: '1440px',

--- a/client/styles/device.ts
+++ b/client/styles/device.ts
@@ -1,7 +1,6 @@
 export const width = Object.freeze({
   mobileS: '320px',
   mobileM: '375px',
-  mobileL: '425px',
   mobile: '425px',
   tablet: '768px',
   laptop: '1024px',


### PR DESCRIPTION
Assigns `width.mobile` to `425px` instead of `1024px`. Changed references from `width.mobileL` to `width.mobile` in code.

Tested visually.