### PR TITLE
💻 Increase z-index of navbar to go over gallery buttons

### DIFF
--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBarContainer = styled.div`
   box-shadow: 0px 2px 10px rgba(34, 34, 34, 0.1);
   position: fixed;
   top: 0;
-  z-index: 1;
+  z-index: 8;
 `
 
 const NavBarOption = styled.a<any>`


### PR DESCRIPTION
## Screenshots

Before
<img width="382" alt="Gallery uh oh" src="https://user-images.githubusercontent.com/30944418/126031205-3eef2b00-4aeb-4d98-b770-a1e9ffa3667f.png">

After
<img width="382" alt="Gallery fixed" src="https://user-images.githubusercontent.com/30944418/126031211-e4351ff6-efed-4c8e-b792-90f465660437.png">

## Purpose

Noticed this weird visual bug while reviewing #169, here's a one-character fix.

## Testing

See screenshots