### PR TITLE
🗄 Convert Dockerfile to multi-stage build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,20 +1,16 @@
-# # stage 1 building the code
-# FROM node:15.9.0-alpine3.13 as development
-# WORKDIR /usr/src/app
-# COPY package*.json ./
-# RUN npm install --only=development
-# COPY . .
-
-# TODO: multistage builds
+# stage 1 (build)
+FROM node:15.9.0-alpine3.13 as development
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --only=development
+COPY . .
+RUN npm run build
 
 # stage 2
 FROM node:15.9.0-alpine3.13
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install
-
-# COPY --from=development /usr/src/app/dist ./dist
-COPY . .
-RUN npm run build
+COPY --from=development /usr/src/app/dist ./dist
 
 CMD ["node", "./dist/index.js"]


### PR DESCRIPTION
## Screenshots
<img width="1450" alt="Screen Shot 2021-07-23 at 8 53 24 PM" src="https://user-images.githubusercontent.com/14998054/126853029-97aac92f-d03e-4f89-80ae-64a3289e9811.png">

<img width="1435" alt="Screen Shot 2021-07-23 at 8 59 39 PM" src="https://user-images.githubusercontent.com/14998054/126853049-f3b9a78a-688e-4d99-a259-78b7fec59a69.png">

Shaved off 3MB our image size.

Before: 369MB 
After: 366MB

A nice 0.8% decrease!!! *sarcasm*

## Purpose
Closes #147 

## Testing
Server runs

#### Blog Posts
- https://docs.docker.com/develop/develop-images/multistage-build/

