### PR TITLE
🗄️ Create express API type system based off OpenAPI

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@loolabs/waterpark-common",
+  "description": "Common types and utilities for Loo Labs' centralized clubs and events platform",
+  "author": "Loo Labs",
+  "version": "0.0.1",
+  "license": "ISC",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "io-ts": "^2.2.16",
+    "typescript": "^4.3.4"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.12",
+    "ts-essentials": "^7.0.1"
+  }
+}

--- a/common/src/demo.ts
+++ b/common/src/demo.ts
@@ -1,0 +1,29 @@
+import { typexpress } from './shared'
+import { api } from './waterpark'
+
+// Example of how to use the typexpress router with a mock Waterpark API schema
+
+const router = new typexpress.Router(api.v1)
+
+router.get('/washrooms/', (_, res) => {
+  res.json({
+    washrooms: [
+      {
+        id: '1234',
+        name: "MC 8th floor mens' bathroom",
+      },
+    ],
+  })
+})
+
+router.get('/washrooms/:id/', (req, res) => {
+  const { id } = req.params
+  console.log(id)
+
+  res.json({
+    washroom: {
+      id: '1234',
+      name: "MC 8th floor mens' bathroom",
+    },
+  })
+})

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,0 +1,2 @@
+export { typexpress } from './shared'
+export { dto, api } from './waterpark'

--- a/common/src/shared/api/compiler.ts
+++ b/common/src/shared/api/compiler.ts
@@ -1,0 +1,11 @@
+import { DeepReadonly } from 'ts-essentials'
+import { Schema } from './schema'
+
+function compiler<Base extends object>() {
+  return function <T extends Base>(obj: T): DeepReadonly<T> {
+    // No point calling Object.freeze, just let Typescript enforce the immutability
+    return obj as DeepReadonly<T>
+  }
+}
+export const Operation = compiler<Schema.Operation>()
+export const API = compiler<Schema.API>()

--- a/common/src/shared/api/get.ts
+++ b/common/src/shared/api/get.ts
@@ -1,0 +1,36 @@
+import * as t from 'io-ts'
+import { Schema } from './schema'
+
+type TypeOf<T> = T extends t.Any ? t.TypeOf<T> : {}
+
+export namespace Get {
+  export type PathName<API extends Schema.API> = keyof API['paths']
+
+  export type Path<
+    API extends Schema.API,
+    PathName extends Get.PathName<API>
+  > = API['paths'][PathName]
+
+  export type OperationName<
+    API extends Schema.API,
+    PathName extends Get.PathName<API>
+  > = keyof Get.Path<API, PathName>
+
+  export type Operation<
+    API extends Schema.API,
+    PathName extends Get.PathName<API>,
+    OperationName extends Get.OperationName<API, PathName>
+  > = Get.Path<API, PathName>[OperationName]
+
+  export type PathParameters<Operation extends Schema.Operation> = TypeOf<
+    Operation['pathParameters']
+  >
+  export type QueryParameters<Operation extends Schema.Operation> = TypeOf<
+    Operation['queryParameters']
+  >
+  export type RequestBody<Operation extends Schema.Operation> = TypeOf<Operation['requestBody']>
+
+  export type ResponseBody<Operation extends Schema.Operation> = TypeOf<
+    Operation['response'] extends Schema.Response ? Operation['response']['body'] : undefined
+  >
+}

--- a/common/src/shared/api/index.ts
+++ b/common/src/shared/api/index.ts
@@ -1,0 +1,3 @@
+export { Schema } from './schema'
+export { Get } from './get'
+export { Operation, API } from './compiler'

--- a/common/src/shared/api/schema.ts
+++ b/common/src/shared/api/schema.ts
@@ -1,0 +1,39 @@
+import * as t from 'io-ts'
+import { DeepReadonly } from 'ts-essentials'
+
+// This module sets up a way to encode RESTful APIs as TypeScript objects.
+// It is based vaguely on Swagger.
+
+export namespace Schema {
+  export type PathName = string
+
+  export type OperationName =
+    | 'all'
+    | 'get'
+    | 'post'
+    | 'put'
+    | 'delete'
+    | 'patch'
+    | 'options'
+    | 'head'
+  export function isOperationName(name: string): name is OperationName {
+    return ['all', 'get', 'post', 'put', 'delete', 'patch', 'options', 'head'].includes(name)
+  }
+
+  // TODO: support multiple responses (e.g. 200, 404)
+  export interface Response {
+    body?: t.Any
+  }
+
+  export interface Operation {
+    pathParameters?: t.Any
+    queryParameters?: t.Any
+    requestBody?: t.Any
+    response?: Response
+  }
+  export type Path = DeepReadonly<Partial<Record<OperationName, Operation>>>
+  export type Paths = DeepReadonly<Partial<Record<PathName, Path>>>
+  export type API = DeepReadonly<{
+    paths: Paths
+  }>
+}

--- a/common/src/shared/express/index.ts
+++ b/common/src/shared/express/index.ts
@@ -1,0 +1,1 @@
+export { Router } from './router'

--- a/common/src/shared/express/router.ts
+++ b/common/src/shared/express/router.ts
@@ -1,0 +1,80 @@
+import { Schema, Get } from '../api'
+import { PathParams } from 'express-serve-static-core'
+import express from 'express'
+import { TypedHandler, TypedRouter } from './types'
+
+export class Router<API extends Schema.API> implements TypedRouter<API> {
+  protected router: express.Router
+
+  constructor(protected api: API, options?: express.RouterOptions) {
+    this.router = express.Router(options)
+  }
+
+  public all<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'all'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.all(path, ...handlers)
+    return this
+  }
+
+  public get<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'get'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.get(path, ...handlers)
+    return this
+  }
+
+  public post<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'post'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.post(path, ...handlers)
+    return this
+  }
+
+  public put<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'put'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.put(path, ...handlers)
+    return this
+  }
+
+  public delete<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'delete'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.delete(path, ...handlers)
+    return this
+  }
+
+  public patch<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'patch'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.patch(path, ...handlers)
+    return this
+  }
+
+  public options<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'options'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.options(path, ...handlers)
+    return this
+  }
+
+  public head<
+    PathName extends Get.PathName<API> & PathParams,
+    OperationName extends Get.OperationName<API, PathName> & 'head'
+  >(path: PathName, ...handlers: Array<TypedHandler<API, PathName, OperationName>>): this {
+    this.router.head(path, ...handlers)
+    return this
+  }
+
+  // TODO: support Router.use
+
+  // TODO: support Router.route
+}

--- a/common/src/shared/express/types.ts
+++ b/common/src/shared/express/types.ts
@@ -1,0 +1,42 @@
+import { Schema, Get } from '../api'
+import { PathParams } from 'express-serve-static-core'
+import express from 'express'
+
+type TypedHandlerForOperation<Operation extends Schema.Operation> = express.RequestHandler<
+  Get.PathParameters<Operation>,
+  Get.ResponseBody<Operation>,
+  Get.RequestBody<Operation>,
+  Get.QueryParameters<Operation>
+>
+
+export type TypedHandler<
+  API extends Schema.API,
+  PathName extends Get.PathName<API>,
+  OperationName extends Get.OperationName<API, PathName>
+> = TypedHandlerForOperation<Get.Operation<API, PathName, OperationName>>
+
+interface TypedMatcher<
+  API extends Schema.API,
+  ReturnType,
+  OperationName extends Schema.OperationName = Schema.OperationName
+> {
+  <PathName extends Get.PathName<API> & PathParams>(
+    path: PathName,
+    ...handlers: Array<
+      TypedHandler<API, PathName, OperationName & Get.OperationName<API, PathName>>
+    >
+  ): ReturnType
+}
+
+export interface TypedRouter<API extends Schema.API> {
+  all: TypedMatcher<API, this, 'all'>
+  get: TypedMatcher<API, this, 'get'>
+  post: TypedMatcher<API, this, 'post'>
+  put: TypedMatcher<API, this, 'put'>
+  delete: TypedMatcher<API, this, 'delete'>
+  patch: TypedMatcher<API, this, 'patch'>
+  options: TypedMatcher<API, this, 'options'>
+  head: TypedMatcher<API, this, 'head'>
+  // use: TypedMatcher<API, this>
+  // route: ??? (TODO)
+}

--- a/common/src/shared/index.ts
+++ b/common/src/shared/index.ts
@@ -1,0 +1,2 @@
+export { Operation, API } from './api'
+export * as typexpress from './express'

--- a/common/src/waterpark/api.ts
+++ b/common/src/waterpark/api.ts
@@ -1,0 +1,33 @@
+import * as t from 'io-ts'
+import { Operation, API } from '../shared'
+import * as dto from './dto'
+
+export const getWashrooms = Operation({
+  response: {
+    body: t.strict({
+      washrooms: t.array(dto.tWashroom),
+    }),
+  },
+})
+
+export const getWashroom = Operation({
+  pathParameters: t.strict({
+    id: t.string,
+  }),
+  response: {
+    body: t.strict({
+      washroom: dto.tWashroom,
+    }),
+  },
+})
+
+export const v1 = API({
+  paths: {
+    '/washrooms/': {
+      get: getWashrooms,
+    },
+    '/washrooms/:id/': {
+      get: getWashroom,
+    },
+  },
+})

--- a/common/src/waterpark/dto/index.ts
+++ b/common/src/waterpark/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './washroom'

--- a/common/src/waterpark/dto/washroom.ts
+++ b/common/src/waterpark/dto/washroom.ts
@@ -1,0 +1,13 @@
+import * as t from 'io-ts'
+
+export interface Washroom {
+  id: string
+  name: string
+  // TODO: the rest
+}
+
+export const tWashroom: t.Type<Washroom> = t.strict({
+  id: t.string,
+  name: t.string,
+  // TODO: the rest
+})

--- a/common/src/waterpark/index.ts
+++ b/common/src/waterpark/index.ts
@@ -1,0 +1,2 @@
+export * as dto from './dto'
+export * as api from './api'

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,0 +1,71 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "lib": ["es6"],
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
+    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
+    "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
+
+    /* Advanced Options */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": ["./src", "demo.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "workspaces": [
     "client",
+    "common",
     "server"
   ]
 }


### PR DESCRIPTION
## Purpose

Part of #42.

I kept trying to integrate the stuff from #85 with waterpark, but my changes became outdated each time we advanced `main` (or each time I decided to change the API type system).

This PR attempts to lock in a final-for-now type system. `schema.ts` defines the main structure of an `API`. Roughly speaking, it is a subset of the [OpenAPI `Paths` object](https://swagger.io/specification/#paths-object).

How does this affect you? Someday, your Waterpark types will be imported from the `/common/src/waterpark/` folder.

## Approach

The OpenAPI standard (a.k.a. Swagger, which we might use someday to externally document our APIs) is quite different from what I put in #85. The most jarring difference is that paths are _not_ recursive (`/washrooms/:id/` is not a child of `/washrooms/`). This prevents us from nesting routers (for now), but it also makes the type system more readable, and allows for flatter schema objects.

Also, OpenAPI resolves some of the discussions from #85 about whether to call something an API or an endpoint. It refers to things as "paths", where each path has one or more "operations". It sounded weird to me at first, but then it grew on me.

## Testing

Ran `npm run build` in `/common/` and it worked.

If you checkout the code, take a look at `demo.ts` to see that the compiler now gives types to the `req` and `res` objects. You can also verify that various invalid router calls get blocked by the compiler.

```ts
router.get('/washrooms/', (_, res) => {
  res.json({ this: 'is not a valid response from GET /washrooms/' })
})

router.get('/not-a-path/', (_, _) => {})

// technically still works, but req and res will contain `never` types
// because there is no POST endpoint for this path
router.post('/washrooms/:id/', (req, res) => {
  // do stuff
})
```

![image](https://user-images.githubusercontent.com/30944418/127746374-47c652bd-ebe9-4813-8148-f64c300ecb8a.png)

## TODOs

The code in `/common/` is not-at-all integrated with `/server/`. There are plenty of Docker nightmares coming in the future when we do integrate it, but that is not a concern for now.

Still not entirely sure what the frontend equivalent of `typexpress` would be.