### PR TITLE
💻 Fix font issues on Windows

### DIFF
--- a/client/components/resource-details/Reviews.tsx
+++ b/client/components/resource-details/Reviews.tsx
@@ -146,7 +146,8 @@ const Rating = styled(
         <RatingLabel>{capitalizeFirstLetter(label)}</RatingLabel>
         <ReactStars
           count={5}
-          char={'⬤'}
+          // Circles are too small on Windows font
+          char={navigator.appVersion.indexOf('Win') != -1 ? '⬤' : '●'} 
           value={score / 20}
           size={24}
           color1={'#DDDDDD'}

--- a/client/components/resource-details/Reviews.tsx
+++ b/client/components/resource-details/Reviews.tsx
@@ -146,7 +146,7 @@ const Rating = styled(
         <RatingLabel>{capitalizeFirstLetter(label)}</RatingLabel>
         <ReactStars
           count={5}
-          char={'●'}
+          char={'⬤'}
           value={score / 20}
           size={24}
           color1={'#DDDDDD'}

--- a/client/components/resource-details/SubmitReview.tsx
+++ b/client/components/resource-details/SubmitReview.tsx
@@ -107,7 +107,7 @@ const ModalRating = styled(
         <RatingLabel>{capitalizeFirstLetter(ratingName)}</RatingLabel>
         <ReactStars
           count={5}
-          char={'●'}
+          char={'⬤'}
           value={rating}
           size={24}
           color1={'#DDDDDD'}

--- a/client/components/resource-details/SubmitReview.tsx
+++ b/client/components/resource-details/SubmitReview.tsx
@@ -107,7 +107,8 @@ const ModalRating = styled(
         <RatingLabel>{capitalizeFirstLetter(ratingName)}</RatingLabel>
         <ReactStars
           count={5}
-          char={'⬤'}
+          // Circles are too small on Windows font
+          char={navigator.appVersion.indexOf('Win') != -1 ? '⬤' : '●'}
           value={rating}
           size={24}
           color1={'#DDDDDD'}

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -1,4 +1,5 @@
 @import '~react-image-gallery/styles/css/image-gallery.css';
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap');
 
 html,
 body {


### PR DESCRIPTION
# Purpose
Closes #202.

# Approach
- Explicitly import `Inter` font in `globals.css`
- Conditionally display larger ⬤ character on Windows

# Screenshots
### Before
![image](https://user-images.githubusercontent.com/58242099/129112154-f0a14faa-cb70-4d99-a117-c4a07c255ba3.png)

### After 
![image](https://user-images.githubusercontent.com/58242099/129112177-0c80e548-a111-4444-9b3e-b4d1a34520d4.png)
